### PR TITLE
Add the ability to specify the config file path via environment manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ For all commands taking in device names (such as : `/on name of device`), the ap
 * `/list` uses the filter as a substring.
 * `/regex` uses the filter as a regex.
 
+## Environment Variables
+
+In some docker environments, configuration via environment variables is a common pattern. For example, this docker image can be run on [TrueNAS via Launch Docker Image](https://www.truenas.com/docs/scale/scaletutorials/apps/docker/) and the absolute path to the config file can be set via `HUBIBOT_CONFIG_FILE`.
+
 ## Troubleshooting
 
 * Set `main:logverbosity` to `DEBUG` in `config.yaml` to get more details. Note: **Hubitat's token is printed in plain text** when `main:logverbosity` is `DEBUG`

--- a/main.py
+++ b/main.py
@@ -474,19 +474,15 @@ class HubiBot:
         self.telegram.updater.start_polling()
         self.telegram.updater.idle()
 
-env_config_file = os.getenv('HUBIBOT_CONFIG_FILE')
-if env_config_file:
-  CONFIG_FILE_PATH = env_config_file
-else:
-  CONFIG_FILE_PATH = Path(__file__).with_name("config.yaml")
 SUPPORTED_PYTHON_MAJOR = 3
 SUPPORTED_PYTHON_MINOR = 11
 
 if sys.version_info < (SUPPORTED_PYTHON_MAJOR, SUPPORTED_PYTHON_MINOR):
     raise Exception(f"Python version {SUPPORTED_PYTHON_MAJOR}.{SUPPORTED_PYTHON_MINOR} or later required. Current version: {platform.python_version()}.")
 
+config_file_path = os.getenv("HUBIBOT_CONFIG_FILE", Path(__file__).with_name("config.yaml"))
 try:
-    with open(CONFIG_FILE_PATH) as config_file:
+    with open(config_file_path) as config_file:
         config = yaml.safe_load(config_file)
 
         for name in {"telegram", "hubitat"}:

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from device import Device, DeviceGroup
 from hubitat import Hubitat
 import logging
 from pathlib import Path
+import os
 import platform
 import pytz  # timezones
 import re

--- a/main.py
+++ b/main.py
@@ -473,8 +473,11 @@ class HubiBot:
         self.telegram.updater.start_polling()
         self.telegram.updater.idle()
 
-
-CONFIG_FILE = "config.yaml"
+env_config_file = os.getenv('HUBIBOT_CONFIG_FILE')
+if env_config_file:
+  CONFIG_FILE_PATH = env_config_file
+else:
+  CONFIG_FILE_PATH = Path(__file__).with_name("config.yaml")
 SUPPORTED_PYTHON_MAJOR = 3
 SUPPORTED_PYTHON_MINOR = 11
 
@@ -482,7 +485,7 @@ if sys.version_info < (SUPPORTED_PYTHON_MAJOR, SUPPORTED_PYTHON_MINOR):
     raise Exception(f"Python version {SUPPORTED_PYTHON_MAJOR}.{SUPPORTED_PYTHON_MINOR} or later required. Current version: {platform.python_version()}.")
 
 try:
-    with open(Path(__file__).with_name(CONFIG_FILE)) as config_file:
+    with open(CONFIG_FILE_PATH) as config_file:
         config = yaml.safe_load(config_file)
 
         for name in {"telegram", "hubitat"}:


### PR DESCRIPTION
This should make it possible to easily run hubibot inside of TrueNAS as an app via the "Launch Docker Image" flow which allows specifying environment variables and mount paths to datasets.

Note: I am not sure how to test this because when I run docker build I end up getting an error about permissions to /home/hubibot/.local due to the pip install command in the Dockerfile. I've never built a docker container so I'm likely running into some user error issues.